### PR TITLE
Support the recent arguement "-l" when running the simulator.

### DIFF
--- a/CompileAndRunScript.sh
+++ b/CompileAndRunScript.sh
@@ -26,7 +26,7 @@ read -n 1 -s -r -p "..."
 
 printf "\n Run the AMBF Simulator.  (On a new terminal)"
 cd ../bin/lin-x86_64/
-gnome-terminal -e "./ambf_simulator"
+gnome-terminal -e "./ambf_simulator -l 3"
 
 
 

--- a/ambf_controller/README.md
+++ b/ambf_controller/README.md
@@ -17,11 +17,16 @@ Currently, a Raven2 test module is developed in the AMBF Controller. To launch
 it correctly, change the settings in [launch.yaml](../ambf_models/descriptions/launch.yaml) by:
 1. Uncomment (line 3):          world config: ./world/raven_world.yaml
 2. Comment out (line 2):        world config: ./world/world.yaml
-3. Make sure Raven2 is enabled: ./multi-bodies/robots/blender-raven2.yaml
 
 ### Running the AMBF Controller:
-Having succesfully completed the steps to build and run the Simulator, one can
-run the AMBF Controller using the following command on a new terminal:
+Having succesfully completed the steps to build, one can run the AMBF Simulator 
+using the following command:
+
+```
+cd ~/ambf/bin/<os>
+./ambf_simulator -l 3
+```
+Then on a second terminal, run the AMBF Controller using the following command:
 
 ```
 cd ~/ambf/bin/<os>


### PR DESCRIPTION
Hi Adnan,
Thanks for accepting the previous pull request.
I noticed a feature where user can choose objects to load into the simulator by commend line argument "-l". So I've updated the README.md in AMBF_controller subfolder and the ./CompileAndRunScript to support that. Nothing else major is changed.
Thanks.

