### PR TITLE
Updated Readme to add 2 dependencies of GLFW

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ AMBF has been tested on **Ubuntu 16.04** and **Ubuntu 18.04**. We need a few ext
 Even though it is recommended to use Linux for the full feature set of AMBF Simulator using ROS, AMBF has been tested on **MacOS Maverick** and **MacOS Mojave** without ROS support. 
 
 ### Building:
-On Linux machines, you might need to install the `libasound2-dev` package.
+On Linux machines, you might need to install the `libasound2-dev` package and external libraries dependencies.
 
 ```
-sudo apt install libasound2-dev
+sudo apt install libasound2-dev libgl1-mesa-dev xorg-dev
 ```
 
 Boost libraires ship with Ubuntu systems, but on Mac OS, you might need to install them explicitly.


### PR DESCRIPTION
I had an installation bug about X11/Xcursor/Xcursor.h missing : adding xorg-dev (who provide Xcursor.h) to the installation dependencies.

Also adding libgl1-mesa-dev since it's a dependencies mentionned in GLFW readme : https://github.com/go-gl/glfw/blob/master/README.md#installation
It should already been installed but on some ROS-platform (probably ROS-base and Individual package install) it's not installed by default.