### PR TITLE
Don't define C_ENABLE_DELTA_DEVICE_SUPPORT if not __arm__ and not __a…

### DIFF
--- a/external/chai3d/src/system/CGlobals.h
+++ b/external/chai3d/src/system/CGlobals.h
@@ -211,7 +211,7 @@
     //--------------------------------------------------------------------
     // HAPTIC DEVICES
     //--------------------------------------------------------------------
-    #if !defined (__arm__)
+    #if !defined (__arm__) && !defined (__aarch64__)
         #define C_ENABLE_DELTA_DEVICE_SUPPORT
     #endif
     #define C_ENABLE_PHANTOM_DEVICE_SUPPORT
@@ -242,7 +242,7 @@
     //--------------------------------------------------------------------
     // HAPTIC DEVICES
     //--------------------------------------------------------------------
-    #if defined (__arm__)
+    #if !defined (__arm__) && !defined (__aarch64__)
         #define C_ENABLE_DELTA_DEVICE_SUPPORT
     #endif
     #define C_ENABLE_LEAP_DEVICE_SUPPORT


### PR DESCRIPTION
* Fixes build issue https://github.com/WPI-AIM/ambf/issues/144 , on a macOS m1 running Ubuntu 20.04 ARM virtual machine. This is because the processor type is being defined as `__aarch64__`. https://sourceforge.net/p/predef/wiki/Architectures/.

* Built and tested simulation running on:
    *  macOS m1 running Ubuntu 20.04 ARM64 via parallels. 
    * Ubuntu 20.04 with amd ryzen

