### PR TITLE
Allowing World / Bodies reset via ROS Comm and Python Client

### DIFF
--- a/ambf_framework/afFramework.cpp
+++ b/ambf_framework/afFramework.cpp
@@ -8849,7 +8849,7 @@ void afNoiseModel::createFromAttribs(afNoiseModelAttribs *a_attribs)
 ///
 afVolume::afVolume(afWorldPtr a_afWorld, afModelPtr a_modelPtr): afBaseObject(afType::VOLUME, a_afWorld, a_modelPtr)
 {
-
+    clearResetFlag();
 }
 
 
@@ -8962,15 +8962,29 @@ void afVolume::update(double dt)
 {
 }
 
+void afVolume::updateSceneObjects()
+{
+    if (m_resetFlag){
+        resetTextures();
+    }
+    afBaseObject::updateSceneObjects();
+}
+
 ///
 /// \brief afVolume::reset
 ///
 void afVolume::reset()
 {
+    setResetFlag();
+}
+
+void afVolume::resetTextures()
+{
     cTexture3dPtr tex = copy3DTexture(m_originalTextureCopy);
     m_voxelObject->setTexture(tex);
     tex->markForUpdate();
     afBaseObject::reset();
+    clearResetFlag();
 }
 
 ///

--- a/ambf_framework/afFramework.cpp
+++ b/ambf_framework/afFramework.cpp
@@ -5850,6 +5850,7 @@ void afWorld::setGlobalNamespace(string a_global_namespace){
 /// \brief afWorld::resetCameras
 ///
 void afWorld::resetCameras(){
+    cerr << "INFO! RESETTING ALL CAMERAS IN THE WORLD " << endl;
     afBaseObjectMap::iterator camIt;
     for (camIt = getCameraMap()->begin() ; camIt != getCameraMap()->end() ; ++camIt){
         camIt->second->reset();
@@ -5857,28 +5858,26 @@ void afWorld::resetCameras(){
 
 }
 
+
 ///
 /// \brief afWorld::resetWorld
 /// \param reset_time
 ///
-void afWorld::resetDynamicBodies(bool reset_time){
-    pausePhysics(true);
-
+void afWorld::resetDynamicBodies(){
+    cerr << "INFO! RESETTING ALL BODIES IN THE WORLD " << endl;
     afBaseObjectMap::iterator rbIt;
-
     for (rbIt = getRigidBodyMap()->begin() ; rbIt != getRigidBodyMap()->end() ; ++rbIt){
         rbIt->second->reset();
     }
-
-    if (reset_time){
-        //        s_bulletWorld->setSimulationTime(0.0);
-    }
-
-    pausePhysics(false);
+    clearResetBodiesFlag();
 }
 
-void afWorld::reset()
-{
+
+///
+/// \brief afWorld::reset
+///
+void afWorld::reset(){
+    cerr << "INFO! RESETTING WORLD" << endl;
     pausePhysics(true);
     for (afModelMap::iterator mIt = m_modelsMap.begin() ; mIt != m_modelsMap.end() ; ++mIt){
         (mIt->second)->reset();
@@ -5886,6 +5885,7 @@ void afWorld::reset()
 
     // Call the reset for all plugins
     pluginsReset();
+    clearResetFlag();
     pausePhysics(false);
 }
 
@@ -5925,6 +5925,16 @@ void afWorld::updateDynamics(double a_interval, double a_wallClock, double a_loo
 {
     // sanity check
     if (a_interval <= 0) { return; }
+
+    if (m_resetFlag){
+        reset();
+        return;
+    }
+
+    if (m_resetBodiesFlag){
+        resetDynamicBodies();
+        return;
+    }
 
     if (m_pausePhx){
         if (m_manualStepPhx > 0){

--- a/ambf_framework/afFramework.h
+++ b/ambf_framework/afFramework.h
@@ -2148,7 +2148,7 @@ public:
 
     void resetCameras();
 
-    void resetDynamicBodies(bool reset_time=false);
+    void resetDynamicBodies();
 
     void reset();
 
@@ -2229,6 +2229,14 @@ public:
     int getPhysicsFrequency(){return m_physicsFreq;}
 
     int getNumDevices(){return m_numDevices;}
+
+    void setResetFlag(){m_resetFlag = true;}
+
+    void clearResetFlag(){m_resetFlag = false;}
+
+    void setResetBodiesFlag(){m_resetBodiesFlag = true;}
+
+    void clearResetBodiesFlag(){m_resetBodiesFlag = false;}
 
 public:
 
@@ -2377,6 +2385,10 @@ private:
     cWorld* m_chaiWorld = nullptr;
 
     bool m_headless = false;
+
+    bool m_resetFlag = false;
+
+    bool m_resetBodiesFlag = false;
 };
 
 

--- a/ambf_framework/afFramework.h
+++ b/ambf_framework/afFramework.h
@@ -2521,7 +2521,11 @@ public:
 
     virtual void update(double dt);
 
+    virtual void updateSceneObjects();
+
     virtual void reset();
+
+    void resetTextures();
 
     virtual cShaderProgramPtr getShaderProgram();
 
@@ -2557,6 +2561,10 @@ public:
 
     static cTexture3dPtr copy3DTexture(cTexture1dPtr tex3D);
 
+    void setResetFlag(){m_resetFlag = true;}
+
+    void clearResetFlag(){m_resetFlag = false;}
+
 protected:
     afVolumeAttributes m_attribs;
     cVoxelObject* m_voxelObject;
@@ -2574,6 +2582,9 @@ private:
     // a sub block of the volume.
     cVector3d m_minCornerInitial;
     cVector3d m_maxCornerInitial;
+
+    // Should not reset the volume from physics thread, only from graphics thread. This flag is for that purpose.
+    bool m_resetFlag;
 };
 
 

--- a/ambf_plugins/core/ros_comm_plugin/WorldCommPlugin.cpp
+++ b/ambf_plugins/core/ros_comm_plugin/WorldCommPlugin.cpp
@@ -88,6 +88,18 @@ void afWorldCommunicationPlugin::worldFetchCommand(afWorldPtr worldPtr, double)
         m_read_count = 0;
     }
 
+    if (m_afWorldCommPtr->get_reset_flag()){
+        std::cerr << "INFO! RESET CALLED FROM WORLD COMM" << std::endl;
+        m_worldPtr->setResetFlag();
+        m_afWorldCommPtr->clear_reset_flag();
+    }
+
+    if (m_afWorldCommPtr->get_reset_bodies_flag()){
+        std::cerr << "INFO! RESET BODIES CALLED FROM WORLD COMM" << std::endl;
+        m_worldPtr->setResetBodiesFlag();
+        m_afWorldCommPtr->clear_reset_bodies_flag();
+    }
+
 }
 
 void afWorldCommunicationPlugin::worldUpdateState(afWorldPtr worldPtr, double dt)

--- a/ambf_plugins/core/ros_comm_plugin/WorldCommPlugin.cpp
+++ b/ambf_plugins/core/ros_comm_plugin/WorldCommPlugin.cpp
@@ -20,6 +20,7 @@ int afWorldCommunicationPlugin::init(const afWorldPtr a_afWorld, const afWorldAt
     bool success = false;
 
     m_afWorldCommPtr.reset(new ambf_comm::World(objName, objNamespace, minFreq, maxFreq, timeOut));
+    m_afWorldCommPtr->enableComm();
     success = true;
 
     return success;

--- a/ambf_ros_modules/ambf_client/python/ambf_client.py
+++ b/ambf_ros_modules/ambf_client/python/ambf_client.py
@@ -51,6 +51,7 @@ from ambf_msgs.msg import RigidBodyState, RigidBodyCmd
 from ambf_msgs.msg import WorldState, WorldCmd
 from ambf_msgs.msg import SensorState, SensorCmd
 from ambf_msgs.msg import VehicleState, VehicleCmd
+from std_msgs.msg import Empty
 import threading
 from geometry_msgs.msg import WrenchStamped
 from ambf_actuator import Actuator
@@ -125,6 +126,10 @@ class Client:
                 world_obj._sub = rospy.Subscriber(topic_name, WorldState, world_obj.ros_cb)
                 world_obj._pub = rospy.Publisher(name=topic_name.replace('/State', '/Command'), data_class=WorldCmd,
                                                  queue_size=10)
+                world_obj._reset_pub = rospy.Publisher(name=topic_name.replace('/State', '/Command/Reset'),
+                                                       data_class=Empty, queue_size=1)
+                world_obj._reset_bodies_pub = rospy.Publisher(
+                    name=topic_name.replace('/State', '/Command/Reset/Bodies'), data_class=Empty, queue_size=1)
                 self._world_handle = world_obj
                 self._objects_dict[world_obj.get_name()] = world_obj
             elif msg_type == 'ambf_msgs/ActuatorState':

--- a/ambf_ros_modules/ambf_client/python/ambf_world.py
+++ b/ambf_ros_modules/ambf_client/python/ambf_world.py
@@ -44,7 +44,7 @@
 
 from ambf_msgs.msg import WorldState, WorldCmd
 from watch_dog import WatchDog
-
+from std_msgs.msg import Empty
 
 class World(WatchDog):
     def __init__(self, a_name):
@@ -54,6 +54,8 @@ class World(WatchDog):
         self._cmd = WorldCmd()
         self._cmd.enable_step_throttling = False
         self._pub = None
+        self._reset_pub = None
+        self._reset_bodies_pub = None
         self._sub = None
         self._pub_flag = True
         self._active = False
@@ -96,3 +98,9 @@ class World(WatchDog):
                 self.console_print('World')
                 self.clear_cmd()
             self._pub.publish(self._cmd)
+
+    def reset(self):
+        self._reset_pub.publish(Empty())
+
+    def reset_bodies(self):
+        self._reset_bodies_pub.publish(Empty())

--- a/ambf_ros_modules/ambf_client/python/tests/ambf_throttle.py
+++ b/ambf_ros_modules/ambf_client/python/tests/ambf_throttle.py
@@ -53,7 +53,7 @@ cmd.step_clock = True
 cmd.n_skip_steps = 1
 
 if len(sys.argv) > 1:
-    print 'Clock Rate Specified as {}'.format(sys.argv[1])
+    print('Clock Rate Specified as {}'.format(sys.argv[1]))
     clock_rate = float(sys.argv[1])
 else:
     clock_rate = 50

--- a/ambf_ros_modules/ambf_server/include/ambf_server/WorldRosCom.h
+++ b/ambf_ros_modules/ambf_server/include/ambf_server/WorldRosCom.h
@@ -46,11 +46,18 @@
 #include "ambf_server/RosComBase.h"
 #include "ambf_msgs/WorldState.h"
 #include "ambf_msgs/WorldCmd.h"
+#include <std_msgs/Empty.h>
 
 class WorldRosCom: public RosComBase<ambf_msgs::WorldState, ambf_msgs::WorldCmd>{
 public:
     WorldRosCom(std::string a_name, std::string a_namespace, int a_freq_min, int a_freq_max, double time_out);
     virtual void init();
+
+    bool get_reset_flag(){return m_resetFlag;}
+    void clear_reset_flag(){m_resetFlag = false;}
+
+    bool get_reset_bodies_flag(){return m_resetBodiesFlag;}
+    void clear_reset_bodies_flag(){m_resetBodiesFlag = false;}
 
 protected:
     bool m_enableSimThrottle;
@@ -59,6 +66,16 @@ protected:
     int m_skip_steps_ctr;
     virtual void reset_cmd();
     void sub_cb(ambf_msgs::WorldCmdConstPtr msg);
+
+private:
+    bool m_resetFlag;
+    bool m_resetBodiesFlag;
+
+    ros::Subscriber m_resetBodiesSub;
+    ros::Subscriber m_resetSub;
+
+    void reset_cb(std_msgs::EmptyConstPtr);
+    void reset_bodies_cb(std_msgs::EmptyConstPtr);
 };
 
 

--- a/ambf_ros_modules/ambf_server/src/WorldRosCom.cpp
+++ b/ambf_ros_modules/ambf_server/src/WorldRosCom.cpp
@@ -62,9 +62,13 @@ void WorldRosCom::init(){
     m_State.sim_step = 0;
     m_enableSimThrottle = false;
     m_stepSim = true;
+    m_resetFlag = false;
+    m_resetBodiesFlag = false;
 
     m_pub = nodePtr->advertise<ambf_msgs::WorldState>("/" + m_namespace + "/" + m_name + "/State", 10);
     m_sub = nodePtr->subscribe("/" + m_namespace + "/" + m_name + "/Command", 10, &WorldRosCom::sub_cb, this);
+    m_resetSub = nodePtr->subscribe("/" + m_namespace + "/" + m_name + "/Command/Reset", 1, &WorldRosCom::reset_cb, this);
+    m_resetBodiesSub = nodePtr->subscribe("/" + m_namespace + "/" + m_name + "/Command/Reset/Bodies", 1, &WorldRosCom::reset_bodies_cb, this);
 
     m_thread = boost::thread(boost::bind(&WorldRosCom::run_publishers, this));
     std::cerr << "INFO! Thread Joined: " << m_name << std::endl;
@@ -98,4 +102,19 @@ void WorldRosCom::sub_cb(ambf_msgs::WorldCmdConstPtr msg){
             m_stepSim = true;
     }
     m_watchDogPtr->acknowledge_wd();
+}
+
+
+///
+/// \brief WorldRosCom::reset_cb
+///
+void WorldRosCom::reset_cb(std_msgs::EmptyConstPtr){
+    m_resetFlag = true;
+}
+
+///
+/// \brief WorldRosCom::reset_bodies_cb
+///
+void WorldRosCom::reset_bodies_cb(std_msgs::EmptyConstPtr){
+    m_resetBodiesFlag = true;
 }

--- a/ambf_simulator/src/ambf_simulator.cpp
+++ b/ambf_simulator/src/ambf_simulator.cpp
@@ -132,6 +132,10 @@ bool g_enableGrippingAssist = true;
 
 bool g_enableNormalMapping = true;
 
+bool g_resetFlag = false;
+
+bool g_bodiesResetFlag = false;
+
 // haptic thread
 std::vector<cThread*> g_hapticsThreads;
 
@@ -605,6 +609,16 @@ void updatePhysics(){
     torque_prev.set(0, 0, 0);
     while(g_simulationRunning)
     {
+        if (g_resetFlag){
+            g_afWorld->reset();
+            g_pluginManager.reset();
+            g_resetFlag = false;
+        }
+
+        if (g_bodiesResetFlag){
+            g_afWorld->resetDynamicBodies();
+            g_bodiesResetFlag = false;
+        }
         g_afWorld->m_freqCounterHaptics.signal(1);
 
         // Take care of any picked body by mouse
@@ -1061,8 +1075,8 @@ void keyCallback(GLFWwindow* a_window, int a_key, int a_scancode, int a_action, 
         // MODS IF THE CTRL KEY IS PRESSED
         // option - If CTRL R is pressed, reset the simulation
         if (a_key == GLFW_KEY_R){
-            printf("Resetting Rigid Bodies\n");
-            g_afWorld->resetDynamicBodies();
+            printf("Setting bodies reset flag\n");
+            g_bodiesResetFlag = true;
 
             // Reset the clutched position of all Physical devices to their
             // simulated dynamic end-effectors
@@ -1142,11 +1156,8 @@ void keyCallback(GLFWwindow* a_window, int a_key, int a_scancode, int a_action, 
     else if (a_mods == GLFW_MOD_ALT){
         // option - Toogle visibility of body frames and softbody skeleton
         if (a_key == GLFW_KEY_R){
-            printf("Resetting The World\n");
-            g_afWorld->reset();
-            g_afWorld->pausePhysics(true);
-            g_pluginManager.reset();
-            g_afWorld->pausePhysics(false);
+            printf("Setting world reset flag \n");
+            g_resetFlag = true;
         }
     }
     else{


### PR DESCRIPTION
The original functionality of resetting the world using `ALT + R` or just the bodies using `CTRL + R` is now possible via the ROS Comm (ROS topics) and the Python Client.

**VIA ROS TOPICS**
Publish to the topic `/ambf/env/World/Command/Reset` or `/ambf/env/World/Command/Reset/Bodies` to reset the whole world or just the bodies respectively.

**VIA PYTHON CLIENT**

```python
from ambf_client import Client
import time
c = Client('my_example')
c.connect()
w = c.get_world_handle()
time.sleep(0.1)
w.reset() # Resets the whole world (Lights, Cams, Volumes, Rigid Bodies, Plugins etc)
time.sleep(0.5)
w.reset_bodies() # Reset Static / Dynamic Rigid Bodies
```