### PR TITLE
Keyboard Control for Object Control GUI

### DIFF
--- a/ambf_ros_modules/examples/object_control_example/control_object.py
+++ b/ambf_ros_modules/examples/object_control_example/control_object.py
@@ -85,10 +85,13 @@ class ObjectControl:
             self.jnt_gui = JointGUI(obj_name, self._n_jnts, jnt_names)
 
     def run(self):
+        counter = 0
         while not rospy.is_shutdown():
-
+            counter += 1
             if self._ctrl_c_space is True:
                 self.obj_gui.App.update()
+                self.process_keyboard_input_c_space(counter)
+
                 px = self.obj_gui.px * self.obj_gui.get_px_scale()
                 py = self.obj_gui.py * self.obj_gui.get_py_scale()
                 pz = self.obj_gui.pz * self.obj_gui.get_pz_scale()
@@ -112,6 +115,7 @@ class ObjectControl:
 
             if self._ctrl_j_space is True:
                 self.jnt_gui.App.update()
+                self.process_keyboard_input_j_space(counter)
                 for i in range(self._n_jnts):
                     try:
                         cmd_scale = float(self.jnt_gui.cmd_scales[i].get())
@@ -129,6 +133,73 @@ class ObjectControl:
                         print('CANNOT UNDERSTAND JOINT CONTROL MODE. SUPPORTED MODES ARE 0, 1, 2 FOR F, P, V')
 
             time.sleep(0.001)
+
+    def process_keyboard_input_c_space(self, counter):
+        step_size = self.obj_gui.resolution
+
+        if (counter % 10 == 0 and 'Slow' in self.obj_gui.key_stack) or ('Slow' not in self.obj_gui.key_stack):
+
+            ####### Cartesian Coordiantes #######
+
+            #x-Axis
+            if 'Forth' in self.obj_gui.key_stack:
+                self.obj_gui.px_slider.set(self.obj_gui.px - step_size)
+            if 'Back' in self.obj_gui.key_stack:
+                self.obj_gui.px_slider.set(self.obj_gui.px + step_size)
+
+            #y-Axis
+            if 'Right' in self.obj_gui.key_stack:
+                self.obj_gui.py_slider.set(self.obj_gui.py + step_size)
+            if 'Left' in self.obj_gui.key_stack:
+                self.obj_gui.py_slider.set(self.obj_gui.py - step_size)
+
+            #z-Axis
+            if 'Up' in self.obj_gui.key_stack:
+                self.obj_gui.pz_slider.set(self.obj_gui.pz + step_size)
+            if 'Down' in self.obj_gui.key_stack:
+                self.obj_gui.pz_slider.set(self.obj_gui.pz - step_size)
+
+            ####### Roll-Pitch-Yaw #######
+
+            #x-Axis
+            if 'Roll+' in self.obj_gui.key_stack:
+                self.obj_gui.rx_slider.set(self.obj_gui.rx + step_size)
+            if 'Roll-' in self.obj_gui.key_stack:
+                self.obj_gui.rx_slider.set(self.obj_gui.rx - step_size)
+
+            #y-Axis
+            if 'Pitch+' in self.obj_gui.key_stack:
+                self.obj_gui.ry_slider.set(self.obj_gui.ry + step_size)
+            if 'Pitch-' in self.obj_gui.key_stack:
+                self.obj_gui.ry_slider.set(self.obj_gui.ry - step_size)
+
+            #z-Axis
+            if 'Yaw+' in self.obj_gui.key_stack:
+                self.obj_gui.rz_slider.set(self.obj_gui.rz + step_size)
+            if 'Yaw-' in self.obj_gui.key_stack:
+                self.obj_gui.rz_slider.set(self.obj_gui.rz - step_size)
+
+
+    def process_keyboard_input_j_space(self, counter):
+        step_size = self.jnt_gui.resolution * 20
+        try:
+            if (counter % 10 == 0 and 'Slow' in self.jnt_gui.key_stack) or ('Slow' not in self.jnt_gui.key_stack):
+                if 'Joint1Open' in self.jnt_gui.key_stack:
+                    self.jnt_gui._cmd_sliders[0].set(self.jnt_gui._cmd_sliders[0].get() + step_size)
+                if 'Joint1Close' in self.jnt_gui.key_stack:
+                    self.jnt_gui._cmd_sliders[0].set(self.jnt_gui._cmd_sliders[0].get() - step_size)
+                if 'Joint2Open' in self.jnt_gui.key_stack:
+                    self.jnt_gui._cmd_sliders[1].set(self.jnt_gui._cmd_sliders[1].get() - step_size)
+                if 'Joint2Close' in self.jnt_gui.key_stack:
+                    self.jnt_gui._cmd_sliders[1].set(self.jnt_gui._cmd_sliders[1].get() + step_size)
+                if 'GrabberClose' in self.jnt_gui.key_stack:
+                    self.jnt_gui._cmd_sliders[0].set(self.jnt_gui._cmd_sliders[0].get() - step_size)
+                    self.jnt_gui._cmd_sliders[1].set(self.jnt_gui._cmd_sliders[1].get() + step_size)
+                if 'GrabberOpen' in self.jnt_gui.key_stack:
+                    self.jnt_gui._cmd_sliders[0].set(self.jnt_gui._cmd_sliders[0].get() + step_size)
+                    self.jnt_gui._cmd_sliders[1].set(self.jnt_gui._cmd_sliders[1].get() - step_size)
+        except Exception:
+            print("Could not handle input")
 
 
 def main():

--- a/ambf_ros_modules/examples/object_control_example/jnt_control_gui.py
+++ b/ambf_ros_modules/examples/object_control_example/jnt_control_gui.py
@@ -56,6 +56,7 @@ class JointGUI:
         self.jnt_cmds = []
         self.jnt_mode = []
         self.cmd_scales = []
+        self.resolution = None
 
         self._cmd_sliders = []
 
@@ -104,6 +105,7 @@ class JointGUI:
         self.jnt_cmds = [0.0] * num_jnts
         self.jnt_mode = [0]*num_jnts
         self.cmd_scales = [0]*num_jnts
+        self.resolution = _resolution
 
         # obj_label = Label(app, text='CONTROLLING OBJECT: ' + obj_name, fg="Red")
         # obj_label.pack(row=0, columnspan=2, pady=5)
@@ -147,3 +149,36 @@ class JointGUI:
 
         reset_cmd_btn = Button(app, text='Reset Cmds', command=self.reset_cmds_cb)
         reset_cmd_btn.grid(row=num_jnts*2, column=1)
+        self.init_keyboard_control(app)
+
+    def init_keyboard_control(self, app):
+        self.key_stack = []
+        inputs = [('y', 'Joint1Open'),
+                  ('Y', 'Joint1Open'),
+                  ('x', 'Joint1Close'),
+                  ('X', 'Joint1Close'),
+                  ('v', 'Joint2Open'),
+                  ('V', 'Joint2Open'),
+                  ('c', 'Joint2Close'),
+                  ('C', 'Joint2Close'),
+                  ('q', 'GrabberClose'),
+                  ('Q', 'GrabberClose'),
+                  ('e', 'GrabberOpen'),
+                  ('E', 'GrabberOpen'),
+                  ('Shift_L', 'Slow')]
+
+        for key, direction in inputs:
+            app.bind('<KeyPress-' + key + '>', functools.partial(key_down, self, direction))
+            app.bind('<KeyRelease-' + key + '>', functools.partial(key_up, self, direction))
+
+        app.bind('<FocusOut>', self.on_focus_out)
+
+    def on_focus_out(self, event):
+        self.key_stack = []
+
+
+def key_down(app, direction, event):
+    app.key_stack.append(direction)
+
+def key_up(app, direction, event):
+    app.key_stack.remove(direction)

--- a/ambf_ros_modules/examples/object_control_example/obj_control_gui.py
+++ b/ambf_ros_modules/examples/object_control_example/obj_control_gui.py
@@ -99,6 +99,8 @@ class ObjectGUI:
         self.ry_scale = None
         self.rz_scale = None
 
+        self.step_size_scale = 1.0
+
         self.cartesian_mode = 0
         self.create_gui(self.App, obj_name)
 
@@ -240,7 +242,7 @@ class ObjectGUI:
         sv = StringVar()
         scale_input = Entry(app, textvariable=sv)
         scale_input.grid(row=row_count, column=0)
-        sv.set("1.0")
+        sv.set("3.0")
         self.px_scale = sv
 
         row_count = row_count + 1
@@ -264,7 +266,7 @@ class ObjectGUI:
         sv = StringVar()
         scale_input = Entry(app, textvariable=sv)
         scale_input.grid(row=row_count, column=0)
-        sv.set("1.0")
+        sv.set("3.0")
         self.py_scale = sv
 
         row_count = row_count + 1
@@ -299,13 +301,13 @@ class ObjectGUI:
 
         row_count = row_count + 1
 
-        zero_xyz = Button(app, width=_width, command=self.zero_p_cb)
+        zero_xyz = Button(app, width=_width, command=self.zero_p_cb, text="Reset Position")
         zero_xyz.grid(row=row_count, column=1)
 
         row_count = row_count + 1
 
-        zero_xyz_label = Label(app, text="Reset Position")
-        zero_xyz_label.grid(row=row_count, column=1)
+        # zero_xyz_label = Label(app, text="Reset Position")
+        # zero_xyz_label.grid(row=row_count, column=1)
 
         row_count = row_count + 1
 
@@ -378,20 +380,64 @@ class ObjectGUI:
 
         row_count = row_count + 1
 
-        zero_rpy = Button(app, width=_width, command=self.zero_r_cb)
+        zero_rpy = Button(app, width=_width, command=self.zero_r_cb, text="Reset Rotation")
         zero_rpy.grid(row=row_count, column=1)
 
         row_count = row_count + 1
 
-        zero_rpy_label = Label(app, text="Reset Rotation")
-        zero_rpy_label.grid(row=row_count, column=1)
+        # zero_rpy_label = Label(app, text="Reset Rotation")
+        # zero_rpy_label.grid(row=row_count, column=1)
 
         row_count = row_count + 1
 
-        zero_all = Button(app, width=_width, command=self.zero_all_cb)
+        zero_all = Button(app, width=_width, command=self.zero_all_cb, text="Reset All")
         zero_all.grid(row=row_count, column=1)
 
         row_count = row_count + 1
 
-        zero_all_label = Label(app, text="Reset All")
-        zero_all_label.grid(row=row_count, column=1)
+        # zero_all_label = Label(app, text="Reset All")
+        # zero_all_label.grid(row=row_count, column=1)
+        self.init_keyboard_control(app)
+
+    def init_keyboard_control(self, app):
+        self.key_stack = []
+        inputs = [('w', 'Forth'),
+                  ('W', 'Forth'),
+                  ('a', 'Left'),
+                  ('A', 'Left'),
+                  ('s', 'Back'),
+                  ('S', 'Back'),
+                  ('d', 'Right'),
+                  ('D', 'Right'),
+                  ('Up', 'Up'),
+                  ('Down', 'Down'),
+                  ('Shift_L', 'Slow'),
+                  ('t', 'Roll+'),
+                  ('T', 'Roll+'),
+                  ('g', 'Roll-'),
+                  ('G', 'Roll-'),
+                  ('f', 'Pitch+'),
+                  ('F', 'Pitch+'),
+                  ('h', 'Pitch-'),
+                  ('H', 'Pitch-'),
+                  ('Left', 'Yaw+'),
+                  ('Right', 'Yaw-')]
+
+        for key, direction in inputs:
+            app.bind('<KeyPress-' + key + '>', functools.partial(key_down, self, direction))
+            app.bind('<KeyRelease-' + key + '>', functools.partial(key_up, self, direction))
+
+        app.bind('<FocusOut>', self.on_focus_out)
+
+    def on_focus_out(self, event):
+        self.key_stack = []
+
+
+def key_down(app, direction, event):
+    app.key_stack.append(direction)
+
+def key_up(app, direction, event):
+    app.key_stack.remove(direction)
+
+
+

--- a/ambf_ros_modules/examples/object_control_example/obj_control_gui.py
+++ b/ambf_ros_modules/examples/object_control_example/obj_control_gui.py
@@ -242,7 +242,7 @@ class ObjectGUI:
         sv = StringVar()
         scale_input = Entry(app, textvariable=sv)
         scale_input.grid(row=row_count, column=0)
-        sv.set("3.0")
+        sv.set("1.0")
         self.px_scale = sv
 
         row_count = row_count + 1
@@ -266,7 +266,7 @@ class ObjectGUI:
         sv = StringVar()
         scale_input = Entry(app, textvariable=sv)
         scale_input.grid(row=row_count, column=0)
-        sv.set("3.0")
+        sv.set("1.0")
         self.py_scale = sv
 
         row_count = row_count + 1


### PR DESCRIPTION
Adds Keyboard control for the Object Control GUI; moved text into Buttons instead of as label. 
Control via Translation: WASD, UP/DOWN, Rotation: TFGH, LEFT/RIGHT, Gripper: YXCV, QE
Hold shift for 10x slow down
Fully customizable in python code