### PR TITLE
Mouse control multipliers fix

### DIFF
--- a/adf_loader/version_1_0/adf_loader_1_0.cpp
+++ b/adf_loader/version_1_0/adf_loader_1_0.cpp
@@ -1254,6 +1254,7 @@ bool ADFLoader_1_0::loadCameraAttribs(YAML::Node *a_node, afCameraAttributes *at
     YAML::Node preProcessingShaderNode = node["preprocessing shaders"];
     YAML::Node depthShaderNode = node["depth compute shaders"];
     YAML::Node multiPassNode = node["multipass"];
+    YAML::Node mouseControlMultiplierNode = node["mouse control multipliers"];
 
     bool valid = true;
 
@@ -1363,6 +1364,21 @@ bool ADFLoader_1_0::loadCameraAttribs(YAML::Node *a_node, afCameraAttributes *at
 
     if (multiPassNode.IsDefined()){
         attribs->m_multiPass = multiPassNode.as<bool>();
+    }
+
+    if (mouseControlMultiplierNode.IsDefined()){
+        if (mouseControlMultiplierNode["pan"].IsDefined()){
+            attribs->m_mouseControlScales.m_pan *= mouseControlMultiplierNode["pan"].as<double>();
+        }
+        if (mouseControlMultiplierNode["rotate"].IsDefined()){
+            attribs->m_mouseControlScales.m_rotate *= mouseControlMultiplierNode["rotate"].as<double>();
+        }
+        if (mouseControlMultiplierNode["scroll"].IsDefined()){
+            attribs->m_mouseControlScales.m_scroll *= mouseControlMultiplierNode["scroll"].as<double>();
+        }
+        if (mouseControlMultiplierNode["arcball"].IsDefined()){
+            attribs->m_mouseControlScales.m_arcball *= mouseControlMultiplierNode["arcball"].as<double>();
+        }
     }
 
     return valid;

--- a/ambf_framework/afAttributes.h
+++ b/ambf_framework/afAttributes.h
@@ -533,6 +533,21 @@ struct afNoiseModelAttribs{
     double m_bias;
 };
 
+struct afMouseControlScales{
+public:
+    afMouseControlScales(){
+        m_pan = 0.01;
+        m_rotate = 0.3;
+        m_arcball = 0.03;
+        m_scroll = 0.1;
+    }
+
+    double m_pan;
+    double m_rotate;
+    double m_scroll;
+    double m_arcball;
+};
+
 ///
 /// \brief The afCameraAttributes struct
 ///
@@ -576,6 +591,7 @@ public:
     uint m_publishDepthInterval;
     afShaderAttributes m_preProcessShaderAttribs;
     afShaderAttributes m_depthComputeShaderAttribs;
+    afMouseControlScales m_mouseControlScales;
     bool m_multiPass;
 
     afImageResolutionAttribs m_publishImageResolution;

--- a/ambf_framework/afFramework.cpp
+++ b/ambf_framework/afFramework.cpp
@@ -6443,6 +6443,8 @@ bool afCamera::createFromAttribs(afCameraAttributes *a_attribs)
 
     setVisibleFlag(a_attribs->m_visible);
 
+    m_mouseControlScales = a_attribs->m_mouseControlScales;
+
     //    a_attribs->m_visible;
     createWindow();
 

--- a/ambf_framework/afFramework.cpp
+++ b/ambf_framework/afFramework.cpp
@@ -5197,14 +5197,14 @@ afWorld::afWorld(): afIdentification(afType::WORLD), afModelManager(this){
     m_enclosureW = 4.0;
     m_enclosureH = 3.0;
 
-    m_pickSphere = new cMesh();
-    cCreateSphere(m_pickSphere, 0.02);
-    m_pickSphere->m_material->setPinkHot();
-    m_pickSphere->setUseDisplayList(true);
-    m_pickSphere->markForUpdate(false);
-    m_pickSphere->setLocalPos(0,0,0);
-    m_pickSphere->setShowEnabled(false);
-    addSceneObjectToWorld(m_pickSphere);
+    m_pickMultiPoint = new cMultiPoint();
+    m_pickMultiPoint->newPoint(cVector3d(0,0,0));
+    m_pickMultiPoint->setPointSize(15);
+    cColorf pickColor; pickColor.setGreenYellow();
+    m_pickMultiPoint->setPointColor(pickColor);
+    m_pickMultiPoint->setShowEnabled(false);
+    addSceneObjectToWorld(m_pickMultiPoint);
+
     m_pickColor.setOrangeTomato();
     m_pickColor.setTransparencyLevel(0.3);
     m_namespace = "";
@@ -6021,8 +6021,8 @@ bool afWorld::pickBody(const cVector3d &rayFromWorld, const cVector3d &rayToWorl
     {
         cVector3d pickPos;
         pickPos << rayCallback.m_hitPointWorld;
-        m_pickSphere->setLocalPos(pickPos);
-        m_pickSphere->setShowEnabled(true);
+        m_pickMultiPoint->setLocalPos(pickPos);
+        m_pickMultiPoint->setShowEnabled(true);
         const btCollisionObject* colObject = rayCallback.m_collisionObject;
         if (colObject->getInternalType() == btCollisionObject::CollisionObjectTypes::CO_RIGID_BODY){
             btRigidBody* body = (btRigidBody*)btRigidBody::upcast(colObject);
@@ -6115,7 +6115,7 @@ bool afWorld::movePickedBody(const cVector3d &rayFromWorld, const cVector3d &ray
 
         newLocation = rayFromWorld + dir;
         // Set the position of grab sphere
-        m_pickSphere->setLocalPos(newLocation);
+        m_pickMultiPoint->setLocalPos(newLocation);
 
         if (m_pickedConstraint){
             btPoint2PointConstraint* pickCon = static_cast<btPoint2PointConstraint*>(m_pickedConstraint);
@@ -6145,7 +6145,7 @@ bool afWorld::movePickedBody(const cVector3d &rayFromWorld, const cVector3d &ray
         dir *= m_oldPickingDist;
 
         newPivotB = rayFromWorld + dir;
-        m_pickSphere->setLocalPos(newPivotB);
+        m_pickMultiPoint->setLocalPos(newPivotB);
         m_pickedNodeGoal = newPivotB;
         return true;
     }
@@ -6170,7 +6170,7 @@ void afWorld::removePickingConstraint(){
     }
 
     if (m_pickedBulletRigidBody){
-        m_pickSphere->setShowEnabled(false);
+        m_pickMultiPoint->setShowEnabled(false);
         m_pickedBulletRigidBody = nullptr;
     }
 
@@ -6179,7 +6179,7 @@ void afWorld::removePickingConstraint(){
     }
 
     if (m_pickedSoftBody){
-        m_pickSphere->setShowEnabled(false);
+        m_pickMultiPoint->setShowEnabled(false);
         m_pickedSoftBody = nullptr;
         m_pickedNodeIdx = -1;
         m_pickedNodeMass = 0;

--- a/ambf_framework/afFramework.h
+++ b/ambf_framework/afFramework.h
@@ -2292,7 +2292,7 @@ public:
 
     cVector3d m_pickedOffset;
 
-    cMesh* m_pickSphere = nullptr;
+    cMultiPoint* m_pickMultiPoint = nullptr;
 
     cPrecisionClock m_wallClock;
 

--- a/ambf_framework/afFramework.h
+++ b/ambf_framework/afFramework.h
@@ -1915,6 +1915,9 @@ public:
 
 public:
     bool m_cam_pressed;
+
+    afMouseControlScales m_mouseControlScales;
+
     GLFWwindow* m_window;
 
     static GLFWwindow* s_mainWindow;

--- a/ambf_simulator/src/ambf_simulator.cpp
+++ b/ambf_simulator/src/ambf_simulator.cpp
@@ -1442,12 +1442,9 @@ void mouseBtnsCallback(GLFWwindow* a_window, int a_button, int a_clicked, int a_
 void mousePosCallback(GLFWwindow* a_window, double a_xpos, double a_ypos){
     afCameraPtr cameraPtr = g_afWorld->getAssociatedCamera(a_window);
     if (cameraPtr != nullptr){
-        int state = glfwGetKey(a_window, GLFW_KEY_LEFT_CONTROL);
-        double speed_scale = 1.0;
-        if (state == GLFW_PRESS)
-        {
-            speed_scale = 0.1;
-        }
+
+        double scale_shift = (glfwGetKey(a_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS) ? 0.1 : 1.0;
+
         cameraPtr->mouse_x[1] = cameraPtr->mouse_x[0];
         cameraPtr->mouse_x[0] = a_xpos;
         cameraPtr->mouse_y[1] = cameraPtr->mouse_y[0];
@@ -1461,9 +1458,8 @@ void mousePosCallback(GLFWwindow* a_window, double a_xpos, double a_ypos){
                 g_pickTo = rayTo;
             }
             else{
-                double scale = 0.01;
-                double x_vel = speed_scale * scale * ( cameraPtr->mouse_x[0] - cameraPtr->mouse_x[1]);
-                double y_vel = speed_scale * scale * ( cameraPtr->mouse_y[0] - cameraPtr->mouse_y[1]);
+                double x_vel = scale_shift * cameraPtr->m_mouseControlScales.m_pan * ( cameraPtr->mouse_x[0] - cameraPtr->mouse_x[1]);
+                double y_vel = scale_shift * cameraPtr->m_mouseControlScales.m_pan  * ( cameraPtr->mouse_y[0] - cameraPtr->mouse_y[1]);
                 if (g_mouse_inverted_y){
                     y_vel = -y_vel;
                 }
@@ -1475,9 +1471,8 @@ void mousePosCallback(GLFWwindow* a_window, double a_xpos, double a_ypos){
 
         if( cameraPtr->mouse_r_clicked ){
             cMatrix3d camRot;
-            double scale = 0.3;
-            double yawVel = speed_scale * scale * ( cameraPtr->mouse_x[0] - cameraPtr->mouse_x[1]); // Yaw
-            double pitchVel = speed_scale * scale * ( cameraPtr->mouse_y[0] - cameraPtr->mouse_y[1]); // Pitch
+            double yawVel = scale_shift * cameraPtr->m_mouseControlScales.m_rotate * ( cameraPtr->mouse_x[0] - cameraPtr->mouse_x[1]); // Yaw
+            double pitchVel = scale_shift * cameraPtr->m_mouseControlScales.m_rotate * ( cameraPtr->mouse_y[0] - cameraPtr->mouse_y[1]); // Pitch
             if (g_mouse_inverted_y){
                 pitchVel = -pitchVel;
             }
@@ -1501,9 +1496,8 @@ void mousePosCallback(GLFWwindow* a_window, double a_xpos, double a_ypos){
 
         if( cameraPtr->mouse_scroll_clicked){
             //                devCam->showTargetPos(true);
-            double scale = 0.03;
-            double horizontalVel = speed_scale * scale * ( cameraPtr->mouse_x[0] - cameraPtr->mouse_x[1]);
-            double verticalVel = speed_scale * scale * ( cameraPtr->mouse_y[0] - cameraPtr->mouse_y[1]);
+            double horizontalVel = scale_shift * cameraPtr->m_mouseControlScales.m_arcball * ( cameraPtr->mouse_x[0] - cameraPtr->mouse_x[1]);
+            double verticalVel = scale_shift * cameraPtr->m_mouseControlScales.m_arcball * ( cameraPtr->mouse_y[0] - cameraPtr->mouse_y[1]);
             if (g_mouse_inverted_y){
                 verticalVel = -verticalVel;
             }
@@ -1547,18 +1541,13 @@ void mousePosCallback(GLFWwindow* a_window, double a_xpos, double a_ypos){
 void mouseScrollCallback(GLFWwindow *a_window, double a_xpos, double a_ypos){
     afCameraPtr cameraPtr = g_afWorld->getAssociatedCamera(a_window);
     if (cameraPtr != nullptr){
-        int state = glfwGetKey(a_window, GLFW_KEY_LEFT_SHIFT);
-        double speed_scale = 1.0;
-        if (state == GLFW_PRESS)
-        {
-            speed_scale = 0.1;
-        }
+
+        double scale_shift = (glfwGetKey(a_window, GLFW_KEY_LEFT_SHIFT) == GLFW_PRESS) ? 0.1 : 1.0;
 
         cameraPtr->mouse_scroll[1] = cameraPtr->mouse_scroll[0];
         cameraPtr->mouse_scroll[0] = -a_ypos;
 
-        double scale = 0.1;
-        cVector3d camVelAlongLook(speed_scale * scale * cameraPtr->mouse_scroll[0], 0, 0);
+        cVector3d camVelAlongLook(scale_shift * cameraPtr->m_mouseControlScales.m_scroll * cameraPtr->mouse_scroll[0], 0, 0);
         cVector3d newTargetPos = cameraPtr->getTargetPosLocal();
         cVector3d newPos = cameraPtr->getLocalTransform() * camVelAlongLook;
         cVector3d dPos = newPos - newTargetPos;
@@ -1567,7 +1556,9 @@ void mouseScrollCallback(GLFWwindow *a_window, double a_xpos, double a_ypos){
         }
 
         if (cameraPtr->isOrthographic()){
-            cameraPtr->getInternalCamera()->setOrthographicView(cameraPtr->getInternalCamera()->getOrthographicViewWidth() + (speed_scale * scale * cameraPtr->mouse_scroll[0]));
+            cameraPtr->getInternalCamera()->setOrthographicView(
+                        cameraPtr->getInternalCamera()->getOrthographicViewWidth()
+                        + (scale_shift * cameraPtr->m_mouseControlScales.m_scroll * cameraPtr->mouse_scroll[0]));
             cameraPtr->setLocalPos( cameraPtr->getLocalTransform() * camVelAlongLook );
         }
         else{


### PR DESCRIPTION
With this PR, users can set optional mouse control multipliers in the relevant camera description in the ADF files. These multipliers are camera-specific, and any specifier is optional. For example:

```yaml

cameras: [camera1, camera2]

camera1:
  namespace: cameras/
  name: cam1
  location: {x: 4.0, y: 0.0, z: 2.0}
  look at: {x: 0.0, y: 0.0, z: -0.5}
  up: {x: 0.0, y: 0.0, z: 1.0}
  clipping plane: {near: 0.1, far: 10.0}
  field view angle: 0.8
  monitor: 0
  mouse control multipliers: {pan: 1.0, rotate: 1.0, scroll: 1.0, arcball: 1.0} # <--- All Optional multipliers set

camera2:
  namespace: cameras/
  name: cam2
  location: {x: 4.0, y: 0.0, z: 2.0}
  look at: {x: 0.0, y: 0.0, z: -0.5}
  up: {x: 0.0, y: 0.0, z: 1.0}
  clipping plane: {near: 0.1, far: 10.0}
  field view angle: 0.8
  monitor: 0
  mouse control multipliers: {pan: 1.0, arcball: 10.0} # <--- Some Optional multipliers set. Others assumed to be 1.0
```