### PR TITLE
Adding support for setting light attenuation in ADF file

### DIFF
--- a/adf_loader/version_1_0/adf_loader_1_0.cpp
+++ b/adf_loader/version_1_0/adf_loader_1_0.cpp
@@ -1162,6 +1162,7 @@ bool ADFLoader_1_0::loadLightAttribs(YAML::Node *a_node, afLightAttributes *attr
     YAML::Node spotExponentNode = node["spot exponent"];
     YAML::Node shadowQualityNode = node["shadow quality"];
     YAML::Node cuttOffAngleNode = node["cutoff angle"];
+    YAML::Node attenuationNode = node["attenuation"];
 
     bool valid = true;
 
@@ -1212,6 +1213,13 @@ bool ADFLoader_1_0::loadLightAttribs(YAML::Node *a_node, afLightAttributes *attr
 
     if (cuttOffAngleNode.IsDefined()){
         attribs->m_cuttoffAngle = cuttOffAngleNode.as<double>();
+    }
+
+    if (attenuationNode.IsDefined()){
+        attribs->m_attenuationDefined = true;
+        if (attenuationNode["constant"].IsDefined()) attribs->m_constantAttenuation = attenuationNode["constant"].as<double>();
+        if (attenuationNode["linear"].IsDefined()) attribs->m_linearAttenuation = attenuationNode["linear"].as<double>();
+        if (attenuationNode["quadratic"].IsDefined()) attribs->m_quadraticAttenuation = attenuationNode["quadratic"].as<double>();
     }
 
     return valid;

--- a/ambf_framework/afAttributes.h
+++ b/ambf_framework/afAttributes.h
@@ -623,10 +623,18 @@ public:
     afLightAttributes(){
         m_spotExponent = 0.7;
         m_cuttoffAngle = 0.7;
+        m_constantAttenuation = 1.0;
+        m_linearAttenuation = 0.0;
+        m_quadraticAttenuation = 0.0;
+        m_attenuationDefined = false;
     }
 
     double m_spotExponent;
     double m_cuttoffAngle;
+    double m_constantAttenuation;
+    double m_linearAttenuation;
+    double m_quadraticAttenuation;
+    bool m_attenuationDefined;
     afVector3d m_direction;
 
     afShadowQualityType m_shadowQuality;

--- a/ambf_framework/afFramework.cpp
+++ b/ambf_framework/afFramework.cpp
@@ -7216,6 +7216,12 @@ bool afLight::createFromAttribs(afLightAttributes *a_attribs)
     m_spotLight->setCutOffAngleDeg(a_attribs->m_cuttoffAngle * (180/3.14));
     m_spotLight->setShadowMapEnabled(true);
 
+    if (a_attribs->m_attenuationDefined){
+        m_spotLight->setAttConstant(a_attribs->m_constantAttenuation);
+        m_spotLight->setAttLinear(a_attribs->m_linearAttenuation);
+        m_spotLight->setAttQuadratic(a_attribs->m_quadraticAttenuation);
+    }
+
     switch (a_attribs->m_shadowQuality) {
     case afShadowQualityType::NO_SHADOW:
         m_spotLight->setShadowMapEnabled(false);
@@ -8302,7 +8308,7 @@ bool afVolume::createFromAttribs(afVolumeAttributes *a_attribs)
             m_voxelObject = new cVoxelObject();
             // Setting transparency before setting the texture ensures that the rendering does not show empty spaces as black
             // and the depth point cloud is able to see the volume
-            m_voxelObject->setTransparencyLevel(1.0);
+//            m_voxelObject->setTransparencyLevel(1.0);
 
             cTexture3dPtr texture = cTexture3d::create();
             texture->setImage(m_multiImage);

--- a/external/chai3d/src/lighting/CSpotLight.cpp
+++ b/external/chai3d/src/lighting/CSpotLight.cpp
@@ -181,6 +181,11 @@ void cSpotLight::renderLightSource(cRenderOptions& a_options)
     // set cutoff angle
     glLightf(m_glLightNumber, GL_SPOT_CUTOFF, m_cutOffAngleDeg); 
 
+    // Set Attenuation Constants
+    glLightf(m_glLightNumber, GL_CONSTANT_ATTENUATION, getAttConstant());
+    glLightf(m_glLightNumber, GL_LINEAR_ATTENUATION, getAttLinear());
+    glLightf(m_glLightNumber, GL_QUADRATIC_ATTENUATION, getAttQuadratic());
+
 #endif
 }
 


### PR DESCRIPTION
Usage: In the light data, set the three optional normalized variables as

```yaml
light1:
  namespace: /ambf/env/lights/
  name: light1
  location: {x: 0.0, y: 0.5, z: 2.5}
  direction: {x: 0, y: 0, z: -1.0}
  spot exponent: 0.3
  shadow quality: 0
  cutoff angle: 0.7
  attenuation: {constant: 1.0, linear: 0.0, quadratic: 0.0}  #<-- All these are optional i.e. any single one can be set by omitting others
```
